### PR TITLE
updating object URL for harvard yenching map

### DIFF
--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -28,7 +28,7 @@ object_list:
     medium: Rubbing from stone stele, ink on paper
     dimensions: "182 × 98 cm"
     location: "Harvard-Yenching Library, Harvard University"
-    link: https://id.lib.harvard.edu/digital_collections/W290684_URN-3:FHCL:10873007
+    link: http://id.lib.harvard.edu/images/olvwork290684/urn-3:FHCL:10873007/catalog
     figure:
       - id: "W290684_URN-3:FHCL:10873007"
   - id: "commonwealth:wh24b054q"


### PR DESCRIPTION
Harvard digital collections URLs changed as of July 31, 2024: https://ask.library.harvard.edu/faq/410492

I noticed that the _Tianwen tu_ URL wasn't resolving. Fixed with this PR. 